### PR TITLE
Include unit relation in article endpoints

### DIFF
--- a/server/src/article/articleModel.ts
+++ b/server/src/article/articleModel.ts
@@ -4,51 +4,76 @@ import { db } from "../db/db.ts";
 import { articles } from "../db/schema.ts";
 
 export type InsertArticle = typeof articles.$inferInsert;
-export type SelectArticle = typeof articles.$inferSelect;
 
 export const getArticles = async () => {
-	const result = await db.query.articles.findMany();
-	return result;
+        const result = await db.query.articles.findMany({
+                with: {
+                        unit: true,
+                },
+        });
+
+        return result;
 };
+
+export type SelectArticle = Awaited<ReturnType<typeof getArticles>>[number];
 
 export const getArticleById = async (id: string): Promise<SelectArticle> => {
-	const [article] = await db.select().from(articles).where(eq(articles.id, id));
+        const article = await db.query.articles.findFirst({
+                where: (article, { eq }) => eq(article.id, id),
+                with: {
+                        unit: true,
+                },
+        });
 
-	if (!article) {
-		throw new Error("Article not found");
-	}
+        if (!article) {
+                throw new Error("Article not found");
+        }
 
-	return article;
+        return article;
 };
 
-export const createArticle = async (article: InsertArticle) => {
-	const result = await db.insert(articles).values(article).returning();
-	if (result.length !== 1) {
-		throw new Error("Article not created");
-	}
-	return result[0] as SelectArticle;
+export const createArticle = async (article: InsertArticle): Promise<SelectArticle> => {
+        const [result] = await db
+                .insert(articles)
+                .values(article)
+                .returning({ id: articles.id });
+
+        if (!result) {
+                throw new Error("Article not created");
+        }
+
+        return await getArticleById(result.id);
 };
 
-export const updateArticle = async (id: string, article: InsertArticle) => {
-	const result = await db
-		.update(articles)
-		.set(article)
-		.where(eq(articles.id, id))
-		.returning();
-	if (result.length !== 1) {
-		throw new Error("Article not updated");
-	}
-	return result[0] as SelectArticle;
+export const updateArticle = async (
+        id: string,
+        article: InsertArticle,
+): Promise<SelectArticle> => {
+        const [updated] = await db
+                .update(articles)
+                .set(article)
+                .where(eq(articles.id, id))
+                .returning({ id: articles.id });
+
+        if (!updated) {
+                throw new Error("Article not updated");
+        }
+
+        return await getArticleById(updated.id);
 };
 
-export const deleteArticle = async (id: string) => {
-	const result = await db
-		.delete(articles)
-		.where(eq(articles.id, id))
-		.returning();
-	if (result.length !== 1) {
-		throw new Error("Article not deleted");
-	}
-	return result[0] as SelectArticle;
+export const deleteArticle = async (id: string): Promise<SelectArticle> => {
+        const article = await getArticleById(id);
+
+        const result = await db
+                .delete(articles)
+                .where(eq(articles.id, id))
+                .returning({ id: articles.id });
+
+        if (result.length !== 1) {
+                throw new Error("Article not deleted");
+        }
+
+        return article;
 };
 // end-auto-generated

--- a/server/src/article/articleRoutes.ts
+++ b/server/src/article/articleRoutes.ts
@@ -1,44 +1,54 @@
 // begin-auto-generated
 import type { Response } from "express";
 import express from "express";
-import type { InsertArticle, SelectArticle } from "../types.ts";
+import type { InsertArticle, SelectArticle } from "./articleService.ts";
 import {
-	createArticle,
-	deleteArticle,
-	getArticleById,
-	getArticles,
-	updateArticle,
+        createArticle,
+        deleteArticle,
+        getArticleById,
+        getArticles,
+        updateArticle,
 } from "./articleService.ts";
 
 export const router = express.Router();
 
+const toInsertArticle = (payload: unknown): InsertArticle => {
+        const { articleNumber, name, description, price, unitId } = (payload ?? {}) as InsertArticle;
+
+        return {
+                articleNumber,
+                name,
+                description,
+                price,
+                unitId,
+        };
+};
+
 router.get("/", async (_req, res: Response<SelectArticle[]>) => {
-	const articles = await getArticles();
-	res.json(articles);
+        const articles = await getArticles();
+        res.json(articles);
 });
 
 router.post("/", async (req, res: Response<SelectArticle>) => {
-	const result: InsertArticle = req.body;
-	const article = await createArticle(result);
-	res.json(article);
+        const article = await createArticle(toInsertArticle(req.body));
+        res.json(article);
 });
 
 router.get("/:id", async (req, res: Response<SelectArticle>) => {
-	const id = req.params.id;
-	const article = await getArticleById(id);
-	res.json(article);
+        const id = req.params.id;
+        const article = await getArticleById(id);
+        res.json(article);
 });
 
 router.put("/:id", async (req, res: Response<SelectArticle>) => {
-	const id = req.params.id;
-	const result: InsertArticle = req.body;
-	const article = await updateArticle(id, result);
-	res.json(article);
+        const id = req.params.id;
+        const article = await updateArticle(id, toInsertArticle(req.body));
+        res.json(article);
 });
 
 router.delete("/:id", async (req, res: Response<SelectArticle>) => {
-	const id = req.params.id;
-	const article = await deleteArticle(id);
-	res.json(article);
+        const id = req.params.id;
+        const article = await deleteArticle(id);
+        res.json(article);
 });
 // end-auto-generated

--- a/server/src/article/articleService.ts
+++ b/server/src/article/articleService.ts
@@ -1,24 +1,29 @@
 // begin-auto-generated
-import type { InsertArticle } from "./articleModel.ts";
+import type { InsertArticle, SelectArticle } from "./articleModel.ts";
 import * as articleModel from "./articleModel.ts";
 
-export const getArticles = async () => {
-	return await articleModel.getArticles();
+export type { InsertArticle, SelectArticle } from "./articleModel.ts";
+
+export const getArticles = async (): Promise<SelectArticle[]> => {
+        return await articleModel.getArticles();
 };
 
-export const createArticle = async (article: InsertArticle) => {
-	return await articleModel.createArticle(article);
+export const createArticle = async (article: InsertArticle): Promise<SelectArticle> => {
+        return await articleModel.createArticle(article);
 };
 
-export const getArticleById = async (id: string) => {
-	return await articleModel.getArticleById(id);
+export const getArticleById = async (id: string): Promise<SelectArticle> => {
+        return await articleModel.getArticleById(id);
 };
 
-export const updateArticle = async (id: string, article: InsertArticle) => {
-	return await articleModel.updateArticle(id, article);
+export const updateArticle = async (
+        id: string,
+        article: InsertArticle,
+): Promise<SelectArticle> => {
+        return await articleModel.updateArticle(id, article);
 };
 
-export const deleteArticle = async (id: string) => {
-	return await articleModel.deleteArticle(id);
+export const deleteArticle = async (id: string): Promise<SelectArticle> => {
+        return await articleModel.deleteArticle(id);
 };
 // end-auto-generated

--- a/server/tests/article/articleRoutes.test.ts
+++ b/server/tests/article/articleRoutes.test.ts
@@ -2,112 +2,118 @@
 import { deepStrictEqual, ok, strictEqual } from "node:assert";
 import test from "node:test";
 import { sql } from "drizzle-orm";
+import type { InsertArticle, SelectArticle } from "../../src/article/articleModel.ts";
 import * as articleModel from "../../src/article/articleModel.ts";
 import { db } from "../../src/db/db.ts";
-import type { InsertArticle, SelectArticle } from "../../src/types.ts";
 
 const createData = async (
-	numberOfArticles: number,
+        numberOfArticles: number,
 ): Promise<SelectArticle[]> => {
-	await db.execute(sql`delete from articles`);
-	const insertArticles: SelectArticle[] = [];
+        await db.execute(sql`delete from articles`);
+        const insertArticles: SelectArticle[] = [];
 
-	for (let i = 0; i < numberOfArticles; i++) {
-		const article = createTestArticle(i.toString());
-		const insertedArticle = await articleModel.createArticle(article);
-		if (!insertedArticle) {
-			throw new Error("Article not created");
-		}
-		insertArticles.push({ id: insertedArticle.id, ...article });
-	}
+        for (let i = 0; i < numberOfArticles; i++) {
+                const article = createTestArticle(i.toString());
+                const insertedArticle = await articleModel.createArticle(article);
+                insertArticles.push(insertedArticle);
+        }
 
-	return insertArticles;
+        return insertArticles;
 };
 
 test("GET /articles responds with JSON array and status 200", async () => {
-	const newArticles = await createData(2);
-	const response = await fetch("http://localhost:3001/articles");
+        const newArticles = await createData(2);
+        const response = await fetch("http://localhost:3001/articles");
 
-	strictEqual(response.status, 200);
-	ok(response.headers.get("content-type")?.includes("application/json"));
+        strictEqual(response.status, 200);
+        ok(response.headers.get("content-type")?.includes("application/json"));
 
-	const data = (await response.json()) as SelectArticle[];
-	const _cleanedArticles = data.map(({ id, ...rest }) => rest);
+        const data = (await response.json()) as SelectArticle[];
+        const _cleanedArticles = data.map(({ id, ...rest }) => rest);
 
-	deepStrictEqual(data, newArticles);
+        deepStrictEqual(data, newArticles);
 });
 
 test("POST /articles responds with JSON and status 200", async () => {
-	await createData(0);
-	const expectedArticle = createTestArticle("1");
-	const response = await fetch("http://localhost:3001/articles", {
-		method: "POST",
-		headers: { "Content-Type": "application/json" },
-		body: JSON.stringify(expectedArticle),
-	});
-	strictEqual(response.status, 200);
-	ok(response.headers.get("content-type")?.includes("application/json"));
-	const { id: _id, ...actualArticle } =
-		(await response.json()) as SelectArticle;
+        await createData(0);
+        const expectedArticle = createTestArticle("1");
+        const response = await fetch("http://localhost:3001/articles", {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify(expectedArticle),
+        });
+        strictEqual(response.status, 200);
+        ok(response.headers.get("content-type")?.includes("application/json"));
+        const actualArticle = (await response.json()) as SelectArticle;
 
-	deepStrictEqual(expectedArticle, actualArticle);
+        strictEqual(actualArticle.unit, null);
+        const { id: _id, unit: _unit, ...actualArticleWithoutIdAndUnit } = actualArticle;
+
+        deepStrictEqual(expectedArticle, actualArticleWithoutIdAndUnit);
 });
 
 test("GET /articles/:id responds with JSON and status 200", async () => {
-	const expectedArticles = await createData(1);
-	strictEqual(expectedArticles.length, 1);
-	const expectedArticle = expectedArticles[0] as SelectArticle;
-	const id = expectedArticle.id;
+        const expectedArticles = await createData(1);
+        strictEqual(expectedArticles.length, 1);
+        const expectedArticle = expectedArticles[0] as SelectArticle;
+        const id = expectedArticle.id;
 
-	const response = await fetch(`http://localhost:3001/articles/${id}`);
-	strictEqual(response.status, 200);
-	ok(response.headers.get("content-type")?.includes("application/json"));
-	const actualArticle = (await response.json()) as SelectArticle;
-	deepStrictEqual(expectedArticle, actualArticle);
+        const response = await fetch(`http://localhost:3001/articles/${id}`);
+        strictEqual(response.status, 200);
+        ok(response.headers.get("content-type")?.includes("application/json"));
+        const actualArticle = (await response.json()) as SelectArticle;
+        deepStrictEqual(expectedArticle, actualArticle);
 });
 
 test("PUT /articles/:id responds with JSON and status 200", async () => {
-	const expectedArticles = await createData(1);
-	strictEqual(expectedArticles.length, 1);
-	const expectedArticle = expectedArticles[0] as SelectArticle;
-	const id = expectedArticle.id;
+        const expectedArticles = await createData(1);
+        strictEqual(expectedArticles.length, 1);
+        const expectedArticle = expectedArticles[0] as SelectArticle;
+        const id = expectedArticle.id;
+        const updatePayload: InsertArticle = {
+                articleNumber: expectedArticle.articleNumber,
+                name: expectedArticle.name,
+                description: expectedArticle.description,
+                price: expectedArticle.price,
+                unitId: expectedArticle.unitId,
+        };
 
-	const response = await fetch(`http://localhost:3001/articles/${id}`, {
-		method: "PUT",
-		headers: { "Content-Type": "application/json" },
-		body: JSON.stringify(expectedArticle),
-	});
-	strictEqual(response.status, 200);
-	ok(response.headers.get("content-type")?.includes("application/json"));
-	const actualArticle = (await response.json()) as SelectArticle;
-	deepStrictEqual(expectedArticle, actualArticle);
+        const response = await fetch(`http://localhost:3001/articles/${id}`, {
+                method: "PUT",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify(updatePayload),
+        });
+        strictEqual(response.status, 200);
+        ok(response.headers.get("content-type")?.includes("application/json"));
+        const actualArticle = (await response.json()) as SelectArticle;
+        deepStrictEqual(expectedArticle, actualArticle);
 });
 
 test("DELETE /articles/:id responds with JSON and status 200", async () => {
-	const expectedArticles = await createData(1);
-	strictEqual(expectedArticles.length, 1);
-	const expectedArticle = expectedArticles[0] as SelectArticle;
-	const id = expectedArticle.id;
+        const expectedArticles = await createData(1);
+        strictEqual(expectedArticles.length, 1);
+        const expectedArticle = expectedArticles[0] as SelectArticle;
+        const id = expectedArticle.id;
 
-	const response = await fetch(`http://localhost:3001/articles/${id}`, {
-		method: "DELETE",
-	});
-	strictEqual(response.status, 200);
-	ok(response.headers.get("content-type")?.includes("application/json"));
-	const actualArticle = (await response.json()) as SelectArticle;
-	deepStrictEqual(expectedArticle, actualArticle);
-	const articles = await articleModel.getArticles();
-	strictEqual(articles.length, 0);
+        const response = await fetch(`http://localhost:3001/articles/${id}`, {
+                method: "DELETE",
+        });
+        strictEqual(response.status, 200);
+        ok(response.headers.get("content-type")?.includes("application/json"));
+        const actualArticle = (await response.json()) as SelectArticle;
+        deepStrictEqual(expectedArticle, actualArticle);
+        const articles = await articleModel.getArticles();
+        strictEqual(articles.length, 0);
 });
 // end-auto-generated
 
 const createTestArticle = (suffix: string): InsertArticle => {
-	const article: InsertArticle = {
-		articleNumber: `000${suffix}`,
-		name: "Test Article",
-		description: "This is a test article",
-		price: 10.99,
-		unitId: null,
-	};
-	return article;
+        const article: InsertArticle = {
+                articleNumber: `000${suffix}`,
+                name: "Test Article",
+                description: "This is a test article",
+                price: 10.99,
+                unitId: null,
+        };
+        return article;
 };


### PR DESCRIPTION
## Summary
- load related unit data in the article model so all CRUD operations return detailed article records
- expose the updated article types through the service and sanitize route payloads before persisting
- update the article route tests to expect unit information and to send clean insert/update payloads

## Testing
- `npm run test` *(fails: node does not support the legacy --test-global-setup flag)*
- `node --test` *(fails: database connection refused because PostgreSQL is not available in the environment)*

------
https://chatgpt.com/codex/tasks/task_b_68cab80b9e28832cb595dd4d033d0aa3